### PR TITLE
Add simple card editor and landing page

### DIFF
--- a/editor/editor.js
+++ b/editor/editor.js
@@ -1,0 +1,26 @@
+function update() {
+  const name = document.getElementById('name').value || 'Card Name';
+  const desc = document.getElementById('description').value || 'Card description';
+  const image = document.getElementById('image').value;
+  const attack = document.getElementById('attack').value || 0;
+  const defense = document.getElementById('defense').value || 0;
+
+  document.getElementById('preview-name').textContent = name;
+  document.getElementById('preview-desc').textContent = desc;
+  document.getElementById('preview-atk').textContent = attack;
+  document.getElementById('preview-def').textContent = defense;
+
+  const img = document.getElementById('preview-image');
+  if (image) {
+    img.src = image;
+    img.style.display = 'block';
+  } else {
+    img.style.display = 'none';
+  }
+}
+
+['name','description','image','attack','defense'].forEach(id => {
+  document.getElementById(id).addEventListener('input', update);
+});
+
+update();

--- a/editor/index.html
+++ b/editor/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Card Editor</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Card Editor</h1>
+  <div class="editor">
+    <form id="cardForm">
+      <label>Name: <input type="text" id="name" /></label>
+      <label>Description:<textarea id="description"></textarea></label>
+      <label>Image URL: <input type="text" id="image" /></label>
+      <label>Attack: <input type="number" id="attack" /></label>
+      <label>Defense: <input type="number" id="defense" /></label>
+    </form>
+    <div class="preview" id="preview">
+      <div class="card">
+        <img id="preview-image" src="" alt="" />
+        <h2 id="preview-name">Card Name</h2>
+        <p id="preview-desc">Card description</p>
+        <div class="stats"><span id="preview-atk">0</span>/<span id="preview-def">0</span></div>
+      </div>
+    </div>
+  </div>
+  <script src="editor.js"></script>
+</body>
+</html>

--- a/editor/style.css
+++ b/editor/style.css
@@ -1,0 +1,30 @@
+body {
+  font-family: sans-serif;
+  margin: 2rem;
+}
+.editor {
+  display: flex;
+  gap: 2rem;
+}
+form {
+  display: flex;
+  flex-direction: column;
+  width: 200px;
+  gap: 0.5rem;
+}
+.card {
+  border: 1px solid #333;
+  padding: 1rem;
+  width: 200px;
+  min-height: 300px;
+}
+.card img {
+  max-width: 100%;
+  height: auto;
+  display: none;
+}
+.stats {
+  margin-top: 1rem;
+  font-weight: bold;
+  text-align: right;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>TCG Card Editor</title>
+  <meta http-equiv="refresh" content="0; url=editor/index.html" />
+</head>
+<body>
+  <p>Redirecting to the card editor... If you are not redirected, <a href="editor/index.html">click here</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Provide landing page that redirects to the card editor
- Implement minimal card editor with live preview, styling, and script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c811cb6be0832b87a694560b75d4e0