### PR TITLE
Add import/export workflow and enrich editor UI

### DIFF
--- a/editor/editor.js
+++ b/editor/editor.js
@@ -1,26 +1,511 @@
-function update() {
-  const name = document.getElementById('name').value || 'Card Name';
-  const desc = document.getElementById('description').value || 'Card description';
-  const image = document.getElementById('image').value;
-  const attack = document.getElementById('attack').value || 0;
-  const defense = document.getElementById('defense').value || 0;
+const DEFAULTS = {
+  name: "Gardien de l'Aube",
+  subtitle: 'Sentinelle solaire',
+  set: 'Édition Alpha',
+  description: 'Incarnez un protecteur ancestral et libérez des combos lumineux qui renversent le cours de la partie.',
+  ability: 'Déclenche un halo protecteur qui restaure 150 PV aux alliés et double la défense du Gardien pendant un tour.',
+  rarity: 'legendary',
+  element: 'lumiere',
+  attack: 320,
+  defense: 280,
+  health: 460,
+};
 
-  document.getElementById('preview-name').textContent = name;
-  document.getElementById('preview-desc').textContent = desc;
-  document.getElementById('preview-atk').textContent = attack;
-  document.getElementById('preview-def').textContent = defense;
+const ELEMENT_THEMES = {
+  arcane: {
+    label: 'Arcane',
+    accent: '#a855f7',
+    soft: 'rgba(168, 85, 247, 0.32)',
+    glow:
+      'radial-gradient(circle at 25% 20%, rgba(168, 85, 247, 0.55), transparent 62%), radial-gradient(circle at 80% 30%, rgba(56, 189, 248, 0.45), transparent 65%)',
+  },
+  feu: {
+    label: 'Flamme',
+    accent: '#f97316',
+    soft: 'rgba(249, 115, 22, 0.35)',
+    glow:
+      'radial-gradient(circle at 20% 25%, rgba(251, 146, 60, 0.55), transparent 60%), radial-gradient(circle at 80% 30%, rgba(249, 115, 22, 0.45), transparent 68%)',
+  },
+  glace: {
+    label: 'Givre',
+    accent: '#38bdf8',
+    soft: 'rgba(56, 189, 248, 0.32)',
+    glow:
+      'radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.55), transparent 60%), radial-gradient(circle at 78% 38%, rgba(14, 165, 233, 0.45), transparent 68%)',
+  },
+  nature: {
+    label: 'Nature',
+    accent: '#22c55e',
+    soft: 'rgba(34, 197, 94, 0.32)',
+    glow:
+      'radial-gradient(circle at 22% 22%, rgba(34, 197, 94, 0.5), transparent 58%), radial-gradient(circle at 80% 35%, rgba(132, 204, 22, 0.45), transparent 68%)',
+  },
+  ombre: {
+    label: 'Ombre',
+    accent: '#6366f1',
+    soft: 'rgba(99, 102, 241, 0.32)',
+    glow:
+      'radial-gradient(circle at 24% 26%, rgba(99, 102, 241, 0.48), transparent 60%), radial-gradient(circle at 78% 32%, rgba(15, 23, 42, 0.65), transparent 72%)',
+  },
+  lumiere: {
+    label: 'Lumière',
+    accent: '#facc15',
+    soft: 'rgba(250, 204, 21, 0.3)',
+    glow:
+      'radial-gradient(circle at 22% 22%, rgba(250, 204, 21, 0.55), transparent 60%), radial-gradient(circle at 78% 32%, rgba(244, 226, 159, 0.5), transparent 72%)',
+  },
+};
 
-  const img = document.getElementById('preview-image');
-  if (image) {
-    img.src = image;
-    img.style.display = 'block';
-  } else {
-    img.style.display = 'none';
+const RARITIES = {
+  common: {
+    label: 'Commune',
+    color: '#cbd5f5',
+    soft: 'rgba(148, 163, 184, 0.18)',
+    border: 'rgba(148, 163, 184, 0.4)',
+  },
+  rare: {
+    label: 'Rare',
+    color: '#38bdf8',
+    soft: 'rgba(56, 189, 248, 0.18)',
+    border: 'rgba(56, 189, 248, 0.4)',
+  },
+  epic: {
+    label: 'Épique',
+    color: '#a855f7',
+    soft: 'rgba(168, 85, 247, 0.2)',
+    border: 'rgba(168, 85, 247, 0.45)',
+  },
+  legendary: {
+    label: 'Légendaire',
+    color: '#facc15',
+    soft: 'rgba(250, 204, 21, 0.22)',
+    border: 'rgba(250, 204, 21, 0.4)',
+  },
+};
+
+const PRESETS = {
+  celestial: {
+    name: "Gardien de l'Aube",
+    subtitle: 'Sentinelle solaire',
+    set: 'Édition Lumen',
+    description: 'Une sentinelle éternelle qui absorbe les ténèbres et renvoie la lumière purifiée sur le champ de bataille.',
+    ability:
+      'Déploie un rempart radiant : réduit de 50% les dégâts subis par vos alliés et restaure 200 PV à la fin du tour.',
+    rarity: 'legendary',
+    element: 'lumiere',
+    attack: 280,
+    defense: 340,
+    health: 540,
+    image: '',
+  },
+  pyromancer: {
+    name: 'Oracle des braises',
+    subtitle: 'Mage incandescent',
+    set: 'Cycle des Cendres',
+    description: 'Un pyromancien visionnaire qui manipule les flammes du futur pour déclencher des combos incendiaires.',
+    ability:
+      "Enchaîne Brasier prophétique : inflige 420 dégâts, puis ajoute un marqueur 'Braised' augmentant vos dégâts de 25%.",
+    rarity: 'epic',
+    element: 'feu',
+    attack: 410,
+    defense: 190,
+    health: 360,
+    image: '',
+  },
+  wildheart: {
+    name: 'Chuchoteur sylvestre',
+    subtitle: 'Druide des clairières',
+    set: 'Cercle de Verdoie',
+    description: 'Gardien des forêts anciennes qui transforme la vitalité de la nature en boucliers druidiques.',
+    ability:
+      'Racines rajeunissantes : rend 220 PV à un allié et augmente sa défense de 35% jusqu’à la fin du prochain tour.',
+    rarity: 'rare',
+    element: 'nature',
+    attack: 260,
+    defense: 310,
+    health: 520,
+    image: '',
+  },
+};
+
+const STAT_MAX = {
+  attack: 600,
+  defense: 600,
+  health: 1000,
+};
+
+const fieldIds = ['name', 'subtitle', 'set', 'description', 'ability', 'image', 'attack', 'defense', 'health', 'rarity', 'element'];
+const numericFields = new Set(['attack', 'defense', 'health']);
+
+const previewCard = document.getElementById('preview-card');
+const previewName = document.getElementById('preview-name');
+const previewSubtitle = document.getElementById('preview-subtitle');
+const previewDesc = document.getElementById('preview-desc');
+const previewAbility = document.getElementById('preview-ability');
+const previewAbilityBlock = document.getElementById('preview-ability-block');
+const previewImage = document.getElementById('preview-image');
+const previewPlaceholder = document.querySelector('.preview-card__placeholder');
+const previewRarity = document.getElementById('preview-rarity');
+const previewElement = document.getElementById('preview-element');
+const previewSet = document.getElementById('preview-set');
+const feedbackEl = document.getElementById('formFeedback');
+
+const STORAGE_KEY = 'tcg-card-studio:last-card';
+const supportsStorage = (() => {
+  try {
+    return typeof window !== 'undefined' && 'localStorage' in window && window.localStorage != null;
+  } catch (error) {
+    return false;
+  }
+})();
+
+let feedbackTimer;
+let saveTimer;
+
+function setTextContent(element, text, isPlaceholder = false) {
+  if (!element) {
+    return;
+  }
+  element.textContent = text;
+  element.classList.toggle('is-placeholder', Boolean(isPlaceholder));
+}
+
+function readText(id, fallback = '') {
+  const input = document.getElementById(id);
+  if (!input) {
+    return { value: '', final: fallback, isFallback: true };
+  }
+  const raw = (input.value ?? '').toString().trim();
+  return {
+    value: raw,
+    final: raw || fallback,
+    isFallback: raw.length === 0,
+  };
+}
+
+function readNumber(id, fallback = 0) {
+  const input = document.getElementById(id);
+  if (!input) {
+    return fallback;
+  }
+  const raw = input.value;
+  if (raw === '') {
+    return 0;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function applyElementTheme(elementValue) {
+  const theme = ELEMENT_THEMES[elementValue] || ELEMENT_THEMES[DEFAULTS.element];
+  if (previewElement) {
+    setTextContent(previewElement, theme.label);
+  }
+  if (previewCard) {
+    previewCard.style.setProperty('--accent', theme.accent);
+    previewCard.style.setProperty('--accent-soft', theme.soft);
+    previewCard.style.setProperty('--glow-gradient', theme.glow);
+    previewCard.dataset.element = elementValue;
   }
 }
 
-['name','description','image','attack','defense'].forEach(id => {
-  document.getElementById(id).addEventListener('input', update);
+function applyRarityTheme(rarityValue) {
+  const rarity = RARITIES[rarityValue] || RARITIES[DEFAULTS.rarity];
+  if (previewRarity) {
+    setTextContent(previewRarity, rarity.label);
+  }
+  if (previewCard) {
+    previewCard.style.setProperty('--rarity-color', rarity.color);
+    previewCard.style.setProperty('--rarity-soft', rarity.soft);
+    previewCard.style.setProperty('--rarity-border', rarity.border);
+    previewCard.dataset.rarity = rarityValue;
+  }
+}
+
+function updateMeter(key, value) {
+  const meter = document.querySelector(`.stat-meter[data-meter="${key}"]`);
+  if (!meter) {
+    return;
+  }
+  const finalValue = Number.isFinite(value) ? value : 0;
+  const max = STAT_MAX[key] || 100;
+  const percent = Math.max(0, Math.min(100, Math.round((finalValue / max) * 100)));
+  const fill = meter.querySelector('.stat-meter__fill');
+  const valueEl = meter.querySelector('.stat-meter__value');
+  if (valueEl) {
+    valueEl.textContent = finalValue;
+  }
+  if (fill) {
+    fill.style.width = `${percent}%`;
+  }
+  meter.setAttribute('aria-valuenow', String(finalValue));
+  meter.setAttribute('aria-valuemax', String(max));
+  meter.setAttribute('aria-valuemin', '0');
+}
+
+function updateImage(name, subtitle) {
+  if (!previewImage) {
+    return;
+  }
+  const imageInput = document.getElementById('image');
+  const imageValue = (imageInput?.value ?? '').trim();
+  if (imageValue) {
+    previewImage.src = imageValue;
+    previewImage.alt = subtitle ? `${name} — ${subtitle}` : name;
+    previewImage.style.display = 'block';
+    previewPlaceholder?.classList.add('is-hidden');
+  } else {
+    previewImage.removeAttribute('src');
+    previewImage.removeAttribute('alt');
+    previewImage.style.display = 'none';
+    previewPlaceholder?.classList.remove('is-hidden');
+  }
+}
+
+function update() {
+  const nameInfo = readText('name', DEFAULTS.name);
+  const subtitleInfo = readText('subtitle', DEFAULTS.subtitle);
+  const setInfo = readText('set', DEFAULTS.set);
+  const descriptionInfo = readText('description', DEFAULTS.description);
+  const abilityInfo = readText('ability', '');
+  const rarityValue = document.getElementById('rarity')?.value || DEFAULTS.rarity;
+  const elementValue = document.getElementById('element')?.value || DEFAULTS.element;
+  const attackValue = readNumber('attack', DEFAULTS.attack);
+  const defenseValue = readNumber('defense', DEFAULTS.defense);
+  const healthValue = readNumber('health', DEFAULTS.health);
+
+  setTextContent(previewName, nameInfo.final, nameInfo.isFallback);
+  setTextContent(previewSubtitle, subtitleInfo.final, subtitleInfo.isFallback);
+  setTextContent(previewDesc, descriptionInfo.final, descriptionInfo.isFallback);
+  setTextContent(previewSet, setInfo.final, false);
+
+  if (abilityInfo.value) {
+    previewAbilityBlock?.removeAttribute('hidden');
+    setTextContent(previewAbility, abilityInfo.final);
+  } else {
+    previewAbilityBlock?.setAttribute('hidden', 'hidden');
+  }
+
+  applyRarityTheme(rarityValue in RARITIES ? rarityValue : DEFAULTS.rarity);
+  applyElementTheme(elementValue in ELEMENT_THEMES ? elementValue : DEFAULTS.element);
+
+  updateMeter('attack', attackValue);
+  updateMeter('defense', defenseValue);
+  updateMeter('health', healthValue);
+
+  updateImage(nameInfo.final, subtitleInfo.value);
+}
+
+function getFormData() {
+  const data = {};
+  fieldIds.forEach((id) => {
+    const input = document.getElementById(id);
+    if (!input) {
+      return;
+    }
+    if (numericFields.has(id)) {
+      const raw = input.value;
+      const parsed = raw === '' ? 0 : Number.parseInt(raw, 10);
+      data[id] = Number.isFinite(parsed) ? parsed : 0;
+    } else {
+      data[id] = (input.value ?? '').toString();
+    }
+  });
+  return data;
+}
+
+function applyData(data) {
+  if (!data || typeof data !== 'object') {
+    return;
+  }
+  fieldIds.forEach((id) => {
+    const input = document.getElementById(id);
+    if (!input) {
+      return;
+    }
+    const value = data[id];
+    if (numericFields.has(id)) {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        input.value = String(value);
+      } else if (typeof value === 'string' && value.trim() !== '') {
+        const parsed = Number.parseInt(value, 10);
+        input.value = Number.isFinite(parsed) ? String(parsed) : '';
+      } else {
+        input.value = '';
+      }
+    } else if (id === 'rarity') {
+      input.value = value in RARITIES ? value : DEFAULTS.rarity;
+    } else if (id === 'element') {
+      input.value = value in ELEMENT_THEMES ? value : DEFAULTS.element;
+    } else if (typeof value === 'string') {
+      input.value = value;
+    } else if (value == null) {
+      input.value = '';
+    } else {
+      input.value = String(value);
+    }
+  });
+  update();
+}
+
+function saveDraftNow(data = getFormData()) {
+  if (!supportsStorage) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch (error) {
+    // Ignore quota errors silently
+  }
+}
+
+function scheduleDraftSave() {
+  if (!supportsStorage) {
+    return;
+  }
+  clearTimeout(saveTimer);
+  saveTimer = window.setTimeout(() => {
+    saveDraftNow();
+  }, 350);
+}
+
+function loadDraft() {
+  if (!supportsStorage) {
+    return false;
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return false;
+    }
+    const data = JSON.parse(raw);
+    applyData(data);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+function showFeedback(message, variant = 'info') {
+  if (!feedbackEl) {
+    return;
+  }
+  feedbackEl.textContent = message;
+  if (variant === 'success' || variant === 'error') {
+    feedbackEl.dataset.variant = variant;
+  } else {
+    delete feedbackEl.dataset.variant;
+  }
+  clearTimeout(feedbackTimer);
+  feedbackTimer = window.setTimeout(() => {
+    feedbackEl.textContent = '';
+    delete feedbackEl.dataset.variant;
+  }, 5000);
+}
+
+function slugify(text) {
+  return (text || '')
+    .toString()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '') || 'ma-carte';
+}
+
+function handleExport() {
+  try {
+    const data = getFormData();
+    const json = JSON.stringify(data, null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const filename = `tcg-card-${slugify(data.name || DEFAULTS.name)}.json`;
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    window.setTimeout(() => URL.revokeObjectURL(url), 1500);
+    showFeedback('Carte exportée au format JSON.', 'success');
+  } catch (error) {
+    showFeedback("Une erreur est survenue lors de l'export.", 'error');
+  }
+}
+
+function handleImport(file) {
+  if (!file) {
+    return;
+  }
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const data = JSON.parse(reader.result);
+      applyData(data);
+      saveDraftNow(getFormData());
+      showFeedback('Carte importée avec succès.', 'success');
+    } catch (error) {
+      showFeedback('Le fichier sélectionné est invalide.', 'error');
+    }
+  };
+  reader.onerror = () => {
+    showFeedback('Impossible de lire le fichier importé.', 'error');
+  };
+  reader.readAsText(file);
+}
+
+const exportButton = document.getElementById('exportButton');
+const importButton = document.getElementById('importButton');
+const importInput = document.getElementById('importInput');
+
+exportButton?.addEventListener('click', handleExport);
+importButton?.addEventListener('click', () => importInput?.click());
+importInput?.addEventListener('change', (event) => {
+  const target = event.target;
+  const file = target?.files?.[0];
+  if (file) {
+    handleImport(file);
+  }
+  if (target) {
+    target.value = '';
+  }
 });
 
-update();
+fieldIds.forEach((id) => {
+  const input = document.getElementById(id);
+  if (!input) {
+    return;
+  }
+  const handler = () => {
+    update();
+    scheduleDraftSave();
+  };
+  if (input.tagName === 'SELECT') {
+    input.addEventListener('change', handler);
+  } else {
+    input.addEventListener('input', handler);
+  }
+});
+
+document.querySelectorAll('[data-preset]').forEach((button) => {
+  button.addEventListener('click', () => {
+    const presetKey = button.getAttribute('data-preset');
+    if (!presetKey || !(presetKey in PRESETS)) {
+      return;
+    }
+    const preset = { ...PRESETS[presetKey] };
+    applyData(preset);
+    saveDraftNow(getFormData());
+    showFeedback('Archétype appliqué !', 'success');
+  });
+});
+
+const draftLoaded = loadDraft();
+if (draftLoaded) {
+  showFeedback('Brouillon rechargé automatiquement.', 'success');
+} else {
+  update();
+  saveDraftNow();
+}

--- a/editor/index.html
+++ b/editor/index.html
@@ -1,29 +1,219 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>Card Editor</title>
-  <link rel="stylesheet" href="style.css" />
-</head>
-<body>
-  <h1>Card Editor</h1>
-  <div class="editor">
-    <form id="cardForm">
-      <label>Name: <input type="text" id="name" /></label>
-      <label>Description:<textarea id="description"></textarea></label>
-      <label>Image URL: <input type="text" id="image" /></label>
-      <label>Attack: <input type="number" id="attack" /></label>
-      <label>Defense: <input type="number" id="defense" /></label>
-    </form>
-    <div class="preview" id="preview">
-      <div class="card">
-        <img id="preview-image" src="" alt="" />
-        <h2 id="preview-name">Card Name</h2>
-        <p id="preview-desc">Card description</p>
-        <div class="stats"><span id="preview-atk">0</span>/<span id="preview-def">0</span></div>
-      </div>
-    </div>
-  </div>
-  <script src="editor.js"></script>
-</body>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Éditeur de cartes — TCG Card Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <a class="app-header__brand" href="../index.html">
+        <span class="app-header__logo">TCG</span>
+        <span class="app-header__text">Card Studio</span>
+      </a>
+      <nav aria-label="Navigation secondaire">
+        <a href="../index.html#features">Fonctionnalités</a>
+        <a href="mailto:contact@example.com">Support</a>
+      </nav>
+    </header>
+
+    <main class="layout" aria-label="Éditeur de cartes">
+      <section class="panel">
+        <h1>Composez votre carte</h1>
+        <p class="panel__lead">
+          Remplissez les champs, appliquez un archétype, importez vos créations précédentes et exportez vos cartes prêtes à
+          jouer en un clic.
+        </p>
+
+        <form id="cardForm" class="form" autocomplete="off">
+          <div class="form__section">
+            <div class="form__section-header">
+              <h2 class="form__section-title">Identité de la carte</h2>
+              <p class="form__section-description">Définissez l'essence de votre héros ou de votre sort signature.</p>
+            </div>
+            <div class="form__grid form__grid--balanced">
+              <div class="form__group">
+                <label class="form__label" for="name">Nom de la carte</label>
+                <input class="form__control" type="text" id="name" value="Gardien de l'Aube" />
+              </div>
+              <div class="form__group">
+                <label class="form__label" for="subtitle">Sous-titre</label>
+                <input class="form__control" type="text" id="subtitle" value="Sentinelle solaire" />
+              </div>
+              <div class="form__group">
+                <label class="form__label" for="set">Extension / Série</label>
+                <input class="form__control" type="text" id="set" value="Édition Alpha" />
+              </div>
+              <div class="form__group">
+                <label class="form__label" for="rarity">Rareté</label>
+                <select class="form__control form__control--select" id="rarity">
+                  <option value="common">Commune</option>
+                  <option value="rare">Rare</option>
+                  <option value="epic">Épique</option>
+                  <option value="legendary" selected>Légendaire</option>
+                </select>
+              </div>
+              <div class="form__group">
+                <label class="form__label" for="element">Affinité élémentaire</label>
+                <select class="form__control form__control--select" id="element">
+                  <option value="arcane">Arcane</option>
+                  <option value="feu">Flamme</option>
+                  <option value="glace">Givre</option>
+                  <option value="nature">Nature</option>
+                  <option value="ombre">Ombre</option>
+                  <option value="lumiere" selected>Lumière</option>
+                </select>
+                <p class="form__hint">L'élément ajuste l'ambiance et les couleurs de votre carte.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="form__section">
+            <div class="form__section-header">
+              <h2 class="form__section-title">Illustration & narration</h2>
+              <p class="form__section-description">Décrivez votre personnage, ajoutez une illustration et sa capacité signature.</p>
+            </div>
+            <div class="form__grid">
+              <div class="form__group">
+                <label class="form__label" for="description">Description</label>
+                <textarea class="form__control form__control--textarea" id="description" rows="4">Incarnez un protecteur ancestral et libérez des combos lumineux qui renversent le cours de la partie.</textarea>
+              </div>
+              <div class="form__group">
+                <label class="form__label" for="ability">Capacité signature</label>
+                <textarea class="form__control form__control--textarea" id="ability" rows="3">Déclenche un halo protecteur qui restaure 150 PV aux alliés et double la défense du Gardien pendant un tour.</textarea>
+                <p class="form__hint">Décrivez un effet spécial, un combo ou un passif marquant.</p>
+              </div>
+              <div class="form__group">
+                <label class="form__label" for="image">URL de l'image</label>
+                <input class="form__control" type="url" id="image" placeholder="https://..." />
+                <p class="form__hint">Utilisez une image verticale de 600×800 px minimum pour un rendu optimal.</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="form__section">
+            <div class="form__section-header">
+              <h2 class="form__section-title">Statistiques & puissance</h2>
+              <p class="form__section-description">Affinez l'équilibrage pour que la carte s'intègre parfaitement à votre deck.</p>
+            </div>
+            <div class="form__grid form__grid--stats">
+              <div class="form__group">
+                <label class="form__label" for="attack">Attaque</label>
+                <input class="form__control" type="number" id="attack" min="0" step="1" value="320" />
+              </div>
+              <div class="form__group">
+                <label class="form__label" for="defense">Défense</label>
+                <input class="form__control" type="number" id="defense" min="0" step="1" value="280" />
+              </div>
+              <div class="form__group">
+                <label class="form__label" for="health">Points de vie</label>
+                <input class="form__control" type="number" id="health" min="0" step="10" value="460" />
+              </div>
+            </div>
+          </div>
+
+          <div class="form__section form__section--presets" id="presets">
+            <div class="form__section-header">
+              <h2 class="form__section-title">Inspiration instantanée</h2>
+              <p class="form__section-description">Chargez un archétype pour démarrer plus vite et adaptez-le à votre univers.</p>
+            </div>
+            <div class="preset-list" role="list">
+              <button type="button" class="preset-card" data-preset="celestial">
+                <span class="preset-card__title">Gardien céleste</span>
+                <span class="preset-card__meta">Mur de lumière • Défense élevée</span>
+              </button>
+              <button type="button" class="preset-card" data-preset="pyromancer">
+                <span class="preset-card__title">Oracle des braises</span>
+                <span class="preset-card__meta">Combo explosif • Attaque dominante</span>
+              </button>
+              <button type="button" class="preset-card" data-preset="wildheart">
+                <span class="preset-card__title">Chuchoteur sylvestre</span>
+                <span class="preset-card__meta">Soins naturels • Endurance accrue</span>
+              </button>
+            </div>
+          </div>
+
+          <div class="form__actions" id="export-tools">
+            <button type="button" class="button button--soft" id="importButton">Importer une carte</button>
+            <input type="file" id="importInput" accept="application/json" hidden />
+            <button type="button" class="button button--primary" id="exportButton">Exporter la carte</button>
+          </div>
+          <p class="form__feedback" id="formFeedback" role="status" aria-live="polite"></p>
+        </form>
+      </section>
+
+      <section class="panel panel--preview" aria-live="polite">
+        <div class="preview" id="preview">
+          <div class="preview-card" id="preview-card">
+            <div class="preview-card__glow"></div>
+            <div class="preview-card__inner">
+              <div class="preview-card__top">
+                <div class="preview-card__badge" id="preview-set">Édition Alpha</div>
+                <div class="preview-card__chips" aria-label="Traits de la carte">
+                  <span class="preview-chip preview-chip--rarity" id="preview-rarity">Légendaire</span>
+                  <span class="preview-chip preview-chip--element" id="preview-element">Lumière</span>
+                </div>
+              </div>
+              <div class="preview-card__art" aria-hidden="true">
+                <img id="preview-image" src="" alt="Illustration de la carte" />
+                <div class="preview-card__placeholder">Ajoutez une illustration éclatante</div>
+              </div>
+              <div class="preview-card__content">
+                <h2 id="preview-name">Gardien de l'Aube</h2>
+                <p class="preview-card__subtitle" id="preview-subtitle">Sentinelle solaire</p>
+                <p id="preview-desc">
+                  Incarnez un protecteur ancestral et libérez des combos lumineux qui renversent le cours de la partie.
+                </p>
+                <div class="preview-card__ability" id="preview-ability-block">
+                  <h3>Capacité signature</h3>
+                  <p id="preview-ability">
+                    Déclenche un halo protecteur qui restaure 150 PV aux alliés et double la défense du Gardien pendant un
+                    tour.
+                  </p>
+                </div>
+              </div>
+              <div class="preview-card__stats" aria-label="Statistiques">
+                <div class="stat-meter" data-meter="health">
+                  <div class="stat-meter__header">
+                    <span class="stat-meter__label">PV</span>
+                    <span class="stat-meter__value" id="preview-health">460</span>
+                  </div>
+                  <div class="stat-meter__bar" role="presentation">
+                    <span class="stat-meter__fill"></span>
+                  </div>
+                </div>
+                <div class="stat-meter" data-meter="attack">
+                  <div class="stat-meter__header">
+                    <span class="stat-meter__label">ATK</span>
+                    <span class="stat-meter__value" id="preview-atk">320</span>
+                  </div>
+                  <div class="stat-meter__bar" role="presentation">
+                    <span class="stat-meter__fill"></span>
+                  </div>
+                </div>
+                <div class="stat-meter" data-meter="defense">
+                  <div class="stat-meter__header">
+                    <span class="stat-meter__label">DEF</span>
+                    <span class="stat-meter__value" id="preview-def">280</span>
+                  </div>
+                  <div class="stat-meter__bar" role="presentation">
+                    <span class="stat-meter__fill"></span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script src="editor.js"></script>
+  </body>
 </html>

--- a/editor/index.html
+++ b/editor/index.html
@@ -28,8 +28,8 @@
       <section class="panel">
         <h1>Composez votre carte</h1>
         <p class="panel__lead">
-          Remplissez les champs, appliquez un archétype, importez vos créations précédentes et exportez vos cartes prêtes à
-          jouer en un clic.
+          Remplissez les champs, appliquez un archétype, importez vos créations précédentes et exportez vos cartes prêtes à jouer
+          en un clic. L'aperçu à droite se met à jour instantanément pour refléter chaque modification.
         </p>
 
         <form id="cardForm" class="form" autocomplete="off">
@@ -174,8 +174,7 @@
                 <div class="preview-card__ability" id="preview-ability-block">
                   <h3>Capacité signature</h3>
                   <p id="preview-ability">
-                    Déclenche un halo protecteur qui restaure 150 PV aux alliés et double la défense du Gardien pendant un
-                    tour.
+                    Déclenche un halo protecteur qui restaure 150 PV aux alliés et double la défense du Gardien pendant un tour.
                   </p>
                 </div>
               </div>

--- a/editor/index.html
+++ b/editor/index.html
@@ -141,9 +141,24 @@
           </div>
 
           <div class="form__actions" id="export-tools">
+            <button type="button" class="button button--ghost" id="resetButton">Réinitialiser</button>
             <button type="button" class="button button--soft" id="importButton">Importer une carte</button>
             <input type="file" id="importInput" accept="application/json" hidden />
+            <button type="button" class="button button--outline" id="copyButton">Copier le JSON</button>
             <button type="button" class="button button--primary" id="exportButton">Exporter la carte</button>
+          </div>
+          <div
+            class="form__dropzone"
+            id="importDropzone"
+            role="button"
+            tabindex="0"
+            aria-label="Glissez-déposez un fichier JSON ou cliquez pour importer une carte"
+          >
+            <div class="form__dropzone-icon" aria-hidden="true">⇪</div>
+            <div class="form__dropzone-text">
+              <strong>Glissez-déposez votre JSON</strong>
+              <span>Déposez un fichier de carte ici ou cliquez pour le sélectionner.</span>
+            </div>
           </div>
           <p class="form__feedback" id="formFeedback" role="status" aria-live="polite"></p>
         </form>

--- a/editor/style.css
+++ b/editor/style.css
@@ -82,6 +82,7 @@ button {
 }
 
 .app-header nav a:hover,
+.app-header nav a:focus,
 .app-header nav a:focus-visible {
   color: var(--accent-strong);
 }
@@ -179,6 +180,12 @@ h1 {
   gap: 0.5rem;
 }
 
+.form__group--inline {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
 .form__label {
   font-weight: 600;
   font-size: 0.95rem;
@@ -195,6 +202,7 @@ h1 {
   transition: border 160ms ease, box-shadow 160ms ease, background 160ms ease;
 }
 
+.form__control:focus,
 .form__control:focus-visible {
   outline: none;
   border-color: rgba(37, 99, 235, 0.6);
@@ -247,6 +255,7 @@ h1 {
 }
 
 .preset-card:hover,
+.preset-card:focus,
 .preset-card:focus-visible {
   border-color: rgba(37, 99, 235, 0.55);
   box-shadow: 0 18px 35px rgba(37, 99, 235, 0.16);
@@ -302,6 +311,7 @@ h1 {
   transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, color 160ms ease;
 }
 
+.button:focus,
 .button:focus-visible {
   outline: 3px solid rgba(37, 99, 235, 0.35);
   outline-offset: 2px;

--- a/editor/style.css
+++ b/editor/style.css
@@ -1,30 +1,575 @@
+:root {
+  color-scheme: light;
+  --page-bg: radial-gradient(circle at 0% 0%, rgba(99, 102, 241, 0.18), transparent 60%),
+    radial-gradient(circle at 100% 30%, rgba(59, 130, 246, 0.22), transparent 58%),
+    #eef2ff;
+  --panel-bg: rgba(255, 255, 255, 0.86);
+  --panel-border: rgba(148, 163, 184, 0.28);
+  --text-primary: #0f172a;
+  --text-secondary: rgba(15, 23, 42, 0.75);
+  --accent: #2563eb;
+  --accent-strong: #1d4ed8;
+  --surface-muted: rgba(15, 23, 42, 0.08);
+  --shadow-soft: 0 24px 50px rgba(15, 23, 42, 0.15);
+  --danger: #dc2626;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-  font-family: sans-serif;
-  margin: 2rem;
-}
-.editor {
-  display: flex;
-  gap: 2rem;
-}
-form {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Poppins', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  color: var(--text-primary);
+  background: var(--page-bg);
   display: flex;
   flex-direction: column;
-  width: 200px;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font-family: inherit;
+}
+
+.app-header {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  padding: clamp(1.5rem, 5vw, 2.5rem) clamp(1.5rem, 6vw, 3rem) 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.app-header__brand {
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.8rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.app-header__logo {
+  width: 46px;
+  height: 46px;
+  border-radius: 16px;
+  background: linear-gradient(160deg, #0f172a, #2563eb 55%, #38bdf8);
+  display: grid;
+  place-items: center;
+  color: #fff;
+  box-shadow: 0 16px 30px rgba(37, 99, 235, 0.25);
+  font-size: 0.9rem;
+}
+
+.app-header nav {
+  display: inline-flex;
+  gap: 1.25rem;
+}
+
+.app-header nav a {
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  transition: color 160ms ease;
+}
+
+.app-header nav a:hover,
+.app-header nav a:focus-visible {
+  color: var(--accent-strong);
+}
+
+.layout {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  flex: 1;
+  display: grid;
+  gap: clamp(1.75rem, 4vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  padding: 0 clamp(1.5rem, 6vw, 3rem) clamp(3rem, 6vw, 4rem);
+}
+
+.panel {
+  background: var(--panel-bg);
+  border-radius: 28px;
+  padding: clamp(1.75rem, 4vw, 2.75rem);
+  border: 1px solid var(--panel-border);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(18px);
+}
+
+.panel--preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+h1 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: clamp(1.85rem, 3vw, 2.4rem);
+}
+
+.panel__lead {
+  margin-top: 0;
+  margin-bottom: 2rem;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form__section {
+  display: grid;
+  gap: 1.5rem;
+  padding-bottom: 1.75rem;
+  border-bottom: 1px solid var(--surface-muted);
+}
+
+.form__section:last-of-type {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.form__section-header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.form__section-title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.form__section-description {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.form__grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.form__grid--balanced {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form__grid--stats {
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.form__group {
+  display: flex;
+  flex-direction: column;
   gap: 0.5rem;
 }
-.card {
-  border: 1px solid #333;
-  padding: 1rem;
-  width: 200px;
-  min-height: 300px;
+
+.form__label {
+  font-weight: 600;
+  font-size: 0.95rem;
 }
-.card img {
-  max-width: 100%;
-  height: auto;
+
+.form__control {
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  background: rgba(255, 255, 255, 0.9);
+  color: inherit;
+  transition: border 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.form__control:focus-visible {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.6);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
+  background: #fff;
+}
+
+.form__control--textarea {
+  resize: vertical;
+  min-height: 140px;
+}
+
+.form__control--select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1.5L6 6.5L11 1.5' stroke='%233863F6' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 1.1rem center;
+  background-size: 12px 8px;
+  padding-right: 2.75rem;
+}
+
+.form__hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.form__section--presets {
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.preset-list {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.preset-card {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: 18px;
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.35rem;
+  text-align: left;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: border 160ms ease, box-shadow 160ms ease, transform 160ms ease, background 160ms ease;
+}
+
+.preset-card:hover,
+.preset-card:focus-visible {
+  border-color: rgba(37, 99, 235, 0.55);
+  box-shadow: 0 18px 35px rgba(37, 99, 235, 0.16);
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.95);
+  outline: none;
+}
+
+.preset-card__title {
+  font-weight: 600;
+}
+
+.preset-card__meta {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.form__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}
+
+.form__feedback {
+  margin: 0;
+  margin-top: 0.75rem;
+  min-height: 1.2em;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  transition: opacity 200ms ease, color 200ms ease;
+}
+
+.form__feedback[data-variant='success'] {
+  color: var(--accent-strong);
+}
+
+.form__feedback[data-variant='error'] {
+  color: var(--danger);
+}
+
+.button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, color 160ms ease;
+}
+
+.button:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.35);
+  outline-offset: 2px;
+}
+
+.button--primary {
+  background: var(--accent-strong);
+  color: #fff;
+  box-shadow: 0 18px 30px rgba(29, 78, 216, 0.32);
+}
+
+.button--primary:hover,
+.button--primary:active {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 34px rgba(29, 78, 216, 0.38);
+}
+
+.button--soft {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--text-primary);
+}
+
+.button--soft:hover,
+.button--soft:active {
+  background: rgba(15, 23, 42, 0.12);
+}
+
+.preview {
+  width: 100%;
+}
+
+.preview-card {
+  position: relative;
+  width: min(380px, 100%);
+  margin: 0 auto;
+  --accent: #38bdf8;
+  --accent-soft: rgba(56, 189, 248, 0.32);
+  --glow-gradient: radial-gradient(circle at 30% 20%, rgba(59, 130, 246, 0.45), transparent 60%),
+    radial-gradient(circle at 80% 30%, rgba(14, 165, 233, 0.35), transparent 60%);
+  --rarity-color: #facc15;
+  --rarity-soft: rgba(250, 204, 21, 0.22);
+  --rarity-border: rgba(250, 204, 21, 0.4);
+}
+
+.preview-card__glow {
+  position: absolute;
+  inset: -20% -10% 20%;
+  background: var(--glow-gradient);
+  filter: blur(22px);
+  opacity: 0.85;
+  z-index: 0;
+}
+
+.preview-card__inner {
+  position: relative;
+  z-index: 1;
+  border-radius: 26px;
+  padding: 1.75rem 1.5rem 1.5rem;
+  background: linear-gradient(200deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.92));
+  color: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-height: 520px;
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.38);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.preview-card__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.preview-card__badge {
+  align-self: flex-start;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  background: var(--accent-soft);
+  color: #e0f2fe;
+}
+
+.preview-card__chips {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.preview-chip {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  background: rgba(148, 163, 184, 0.22);
+  color: #e2e8f0;
+  border: 1px solid transparent;
+}
+
+.preview-chip--rarity {
+  background: var(--rarity-soft);
+  border-color: var(--rarity-border);
+  color: var(--rarity-color);
+}
+
+.preview-chip--element {
+  background: var(--accent-soft);
+  color: #f8fafc;
+}
+
+.preview-card__art {
+  position: relative;
+  border-radius: 18px;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.55);
+  height: 220px;
+  display: grid;
+  place-items: center;
+}
+
+.preview-card__art img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
   display: none;
 }
-.stats {
-  margin-top: 1rem;
-  font-weight: bold;
-  text-align: right;
+
+.preview-card__placeholder {
+  color: rgba(226, 232, 240, 0.8);
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 0 1rem;
+  transition: opacity 200ms ease, transform 200ms ease;
+}
+
+.preview-card__placeholder.is-hidden {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
+.preview-card__content {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.preview-card__content h2 {
+  margin: 0;
+  font-size: 1.7rem;
+  letter-spacing: 0.02em;
+}
+
+.preview-card__subtitle {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.8);
+  font-weight: 500;
+}
+
+.preview-card__content p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.84);
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+.preview-card .is-placeholder {
+  opacity: 0.65;
+  font-style: italic;
+}
+
+.preview-card__ability {
+  margin-top: 0.5rem;
+  padding: 1rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: grid;
+  gap: 0.45rem;
+}
+
+.preview-card__ability h3 {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.preview-card__ability[hidden] {
+  display: none;
+}
+
+.preview-card__stats {
+  margin-top: auto;
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.stat-meter {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.85rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.stat-meter__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.stat-meter__label {
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.stat-meter__bar {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+  overflow: hidden;
+}
+
+.stat-meter__fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(248, 250, 252, 0.9), var(--accent));
+  transform-origin: left;
+  width: 0%;
+  transition: width 220ms ease;
+}
+
+@media (max-width: 900px) {
+  .app-header nav {
+    display: none;
+  }
+
+  .panel {
+    padding: clamp(1.5rem, 5vw, 2.25rem);
+  }
+
+  .preview-card__inner {
+    min-height: 480px;
+  }
+
+  .form__actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/editor/style.css
+++ b/editor/style.css
@@ -277,8 +277,65 @@ h1 {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-  justify-content: flex-end;
+  justify-content: flex-start;
   margin-top: 0.5rem;
+}
+
+.form__dropzone {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.5rem;
+  padding: 1rem 1.25rem;
+  border-radius: 18px;
+  border: 1px dashed rgba(37, 99, 235, 0.35);
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: border-color 160ms ease, background 160ms ease, transform 160ms ease;
+  user-select: none;
+}
+
+.form__dropzone:hover {
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.form__dropzone:focus,
+.form__dropzone:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.35);
+  outline-offset: 2px;
+}
+
+.form__dropzone.is-active {
+  border-color: rgba(37, 99, 235, 0.65);
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.form__dropzone-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent-strong);
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.form__dropzone-text {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.form__dropzone-text strong {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.form__dropzone-text span {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
 }
 
 .form__feedback {
@@ -337,6 +394,29 @@ h1 {
 .button--soft:hover,
 .button--soft:active {
   background: rgba(15, 23, 42, 0.12);
+}
+
+.button--ghost {
+  border: 1px solid rgba(15, 23, 42, 0.14);
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.button--ghost:hover,
+.button--ghost:active {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--text-primary);
+}
+
+.button--outline {
+  border: 1px solid rgba(37, 99, 235, 0.55);
+  background: transparent;
+  color: var(--accent-strong);
+}
+
+.button--outline:hover,
+.button--outline:active {
+  background: rgba(59, 130, 246, 0.12);
 }
 
 .preview {
@@ -570,6 +650,19 @@ h1 {
 
   .form__actions {
     justify-content: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .form__dropzone {
+    flex-direction: column;
+    text-align: center;
+    align-items: center;
+  }
+
+  .form__dropzone-icon {
+    width: 48px;
+    height: 48px;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -1,11 +1,480 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>TCG Card Editor</title>
-  <meta http-equiv="refresh" content="0; url=editor/index.html" />
-</head>
-<body>
-  <p>Redirecting to the card editor... If you are not redirected, <a href="editor/index.html">click here</a>.</p>
-</body>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TCG Card Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: linear-gradient(160deg, #0f172a, #1d4ed8 55%, #38bdf8);
+        --card-bg: rgba(15, 23, 42, 0.6);
+        --text-primary: #0f172a;
+        --text-secondary: rgba(15, 23, 42, 0.75);
+        --accent: #38bdf8;
+        --accent-strong: #1d4ed8;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: 'Poppins', 'Segoe UI', system-ui, -apple-system, sans-serif;
+        color: var(--text-primary);
+        background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.35), transparent 55%),
+          radial-gradient(circle at bottom left, rgba(29, 78, 216, 0.35), transparent 45%),
+          #f1f5f9;
+      }
+
+      .top-bar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: clamp(1.5rem, 5vw, 2.5rem) clamp(1.5rem, 6vw, 4rem) 0;
+      }
+
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        text-decoration: none;
+        color: inherit;
+      }
+
+      .brand__logo {
+        width: 48px;
+        height: 48px;
+        display: grid;
+        place-items: center;
+        border-radius: 16px;
+        background: var(--bg);
+        color: white;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        box-shadow: 0 18px 35px rgba(15, 23, 42, 0.2);
+      }
+
+      .brand__text {
+        font-size: 1.25rem;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+      }
+
+      .top-bar nav {
+        display: flex;
+        gap: 1rem;
+      }
+
+      .top-bar a {
+        color: var(--text-secondary);
+        text-decoration: none;
+        font-size: 0.95rem;
+        font-weight: 500;
+        transition: color 200ms ease;
+      }
+
+      .top-bar a:hover,
+      .top-bar a:focus {
+        color: var(--accent-strong);
+      }
+
+      main {
+        display: grid;
+        gap: 3rem;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        align-items: center;
+        padding: clamp(2rem, 6vw, 4rem) clamp(1.5rem, 6vw, 4rem) clamp(4rem, 8vw, 6rem);
+        max-width: 1120px;
+        margin: 0 auto;
+      }
+
+      .hero__eyebrow {
+        text-transform: uppercase;
+        letter-spacing: 0.26em;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: var(--accent-strong);
+      }
+
+      h1 {
+        font-size: clamp(2.5rem, 4vw, 3.5rem);
+        line-height: 1.05;
+        margin: 0.75rem 0 1rem;
+      }
+
+      .hero__description {
+        margin: 0;
+        font-size: 1.05rem;
+        line-height: 1.6;
+        color: var(--text-secondary);
+      }
+
+      .hero__highlights {
+        margin: 1.75rem 0 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 0.75rem;
+      }
+
+      .hero__highlights li {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        background: rgba(56, 189, 248, 0.14);
+        border-radius: 18px;
+        padding: 0.75rem 1rem;
+        font-size: 0.9rem;
+        color: var(--text-secondary);
+        box-shadow: 0 12px 28px rgba(56, 189, 248, 0.18);
+      }
+
+      .hero__highlights span {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 0.72rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.2em;
+        color: var(--accent-strong);
+        background: rgba(255, 255, 255, 0.9);
+        border-radius: 999px;
+        padding: 0.35rem 0.75rem;
+        flex-shrink: 0;
+      }
+
+      .hero__actions {
+        margin-top: 1.75rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+      }
+
+      .button {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        border-radius: 999px;
+        padding: 0.75rem 1.5rem;
+        font-weight: 600;
+        font-size: 1rem;
+        text-decoration: none;
+        transition: transform 200ms ease, box-shadow 200ms ease, background 200ms ease,
+          color 200ms ease;
+      }
+
+      .button--primary {
+        background: var(--accent-strong);
+        color: white;
+        box-shadow: 0 18px 30px rgba(29, 78, 216, 0.32);
+      }
+
+      .button--primary:hover,
+      .button--primary:focus {
+        transform: translateY(-2px);
+        box-shadow: 0 22px 34px rgba(29, 78, 216, 0.36);
+      }
+
+      .button--ghost {
+        background: rgba(15, 23, 42, 0.08);
+        color: var(--text-primary);
+      }
+
+      .button--ghost:hover,
+      .button--ghost:focus {
+        background: rgba(15, 23, 42, 0.14);
+      }
+
+      .button--outline {
+        background: transparent;
+        border: 1px solid rgba(15, 23, 42, 0.15);
+        color: var(--text-primary);
+      }
+
+      .button--outline:hover,
+      .button--outline:focus {
+        background: rgba(15, 23, 42, 0.08);
+      }
+
+      .hero__card-preview {
+        position: relative;
+        padding: clamp(1.5rem, 4vw, 2.5rem);
+      }
+
+      .card-mockup {
+        position: relative;
+        width: min(320px, 100%);
+        margin-left: auto;
+        margin-right: auto;
+        aspect-ratio: 3 / 4.4;
+        border-radius: 26px;
+        padding: 1.75rem 1.5rem;
+        background: var(--card-bg);
+        backdrop-filter: blur(26px);
+        color: white;
+        box-shadow: 0 32px 70px rgba(15, 23, 42, 0.35);
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .card-mockup::before {
+        content: '';
+        position: absolute;
+        inset: -40% -30% auto;
+        height: 65%;
+        background: var(--bg);
+        filter: blur(0px);
+        opacity: 0.85;
+        transform: rotate(-8deg);
+        border-radius: 40px;
+        z-index: 0;
+      }
+
+      .card-mockup__header {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .card-mockup__type {
+        font-size: 0.75rem;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+        opacity: 0.8;
+      }
+
+      .card-mockup__name {
+        position: relative;
+        z-index: 1;
+        font-size: 1.45rem;
+        letter-spacing: 0.02em;
+        font-weight: 600;
+      }
+
+      .card-mockup__art {
+        position: relative;
+        z-index: 1;
+        border-radius: 18px;
+        background: rgba(15, 23, 42, 0.35);
+        height: 150px;
+        display: grid;
+        place-items: center;
+        overflow: hidden;
+      }
+
+      .card-mockup__art span {
+        font-size: 0.85rem;
+        opacity: 0.75;
+      }
+
+      .card-mockup__desc {
+        position: relative;
+        z-index: 1;
+        font-size: 0.85rem;
+        line-height: 1.5;
+        opacity: 0.9;
+      }
+
+      .card-mockup__stats {
+        position: relative;
+        z-index: 1;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-top: auto;
+        padding-top: 0.5rem;
+        border-top: 1px solid rgba(148, 163, 184, 0.35);
+        font-weight: 600;
+        letter-spacing: 0.05em;
+      }
+
+      .features {
+        margin: 0 auto clamp(5rem, 10vw, 6.5rem);
+        max-width: 1120px;
+        padding: 0 clamp(1.5rem, 6vw, 4rem);
+      }
+
+      .features__title {
+        text-align: center;
+        font-size: clamp(1.75rem, 3vw, 2.35rem);
+        margin-bottom: 2.5rem;
+      }
+
+      .feature-grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+
+      .feature {
+        background: white;
+        border-radius: 20px;
+        padding: 1.75rem;
+        box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        display: grid;
+        gap: 0.65rem;
+        align-content: start;
+      }
+
+      .feature--accent {
+        border-color: rgba(56, 189, 248, 0.32);
+        box-shadow: 0 18px 36px rgba(56, 189, 248, 0.18);
+      }
+
+      .feature__badge {
+        display: inline-flex;
+        align-items: center;
+        font-size: 0.7rem;
+        letter-spacing: 0.22em;
+        text-transform: uppercase;
+        color: var(--accent-strong);
+        background: rgba(56, 189, 248, 0.16);
+        border-radius: 999px;
+        padding: 0.35rem 0.6rem;
+      }
+
+      .feature h3 {
+        margin: 0 0 0.75rem;
+        font-size: 1.15rem;
+      }
+
+      .feature p {
+        margin: 0;
+        color: var(--text-secondary);
+        line-height: 1.55;
+      }
+
+      footer {
+        text-align: center;
+        padding: 0 1.5rem 2.5rem;
+        color: rgba(15, 23, 42, 0.65);
+        font-size: 0.9rem;
+      }
+
+      @media (max-width: 720px) {
+        .top-bar nav {
+          display: none;
+        }
+
+        .top-bar {
+          padding-bottom: 0;
+        }
+
+        main {
+          gap: 2.5rem;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        *,
+        *::before,
+        *::after {
+          animation-duration: 0.01ms !important;
+          animation-iteration-count: 1 !important;
+          transition-duration: 0.01ms !important;
+          scroll-behavior: auto !important;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="top-bar">
+      <a href="#top" class="brand" aria-label="Accueil TCG Card Studio">
+        <span class="brand__logo">TCG</span>
+        <span class="brand__text">Card Studio</span>
+      </a>
+      <nav aria-label="Navigation principale">
+        <a href="#features">Fonctionnalités</a>
+        <a href="editor/index.html">Accéder à l'éditeur</a>
+      </nav>
+    </header>
+
+    <main>
+      <section class="hero__content">
+        <span class="hero__eyebrow">Créez votre univers</span>
+        <h1>Donnez vie à vos cartes de jeu en quelques clics</h1>
+        <p class="hero__description">
+          Composez vos cartes de jeu de façon intuitive&nbsp;: ajoutez une illustration, personnalisez le nom, la description et
+          ajustez les statistiques. Importez vos anciennes créations, sauvegardez automatiquement vos brouillons et exportez le
+          résultat en un clic.
+        </p>
+        <ul class="hero__highlights" role="list">
+          <li><span>Nouveau</span> Importez ou exportez vos cartes au format JSON pour les partager instantanément.</li>
+          <li><span>Archétypes</span> Lancez-vous grâce à des presets inspirants que vous adaptez en quelques secondes.</li>
+          <li><span>Brouillon</span> Votre progression est enregistrée localement à chaque modification.</li>
+        </ul>
+        <div class="hero__actions">
+          <a class="button button--primary" href="editor/index.html">Ouvrir l'éditeur</a>
+          <a class="button button--ghost" href="#features">Découvrir les fonctionnalités</a>
+          <a class="button button--outline" href="editor/index.html#export-tools">Importer une création</a>
+        </div>
+      </section>
+      <section class="hero__card-preview" aria-label="Exemple de carte générée">
+        <div class="card-mockup">
+          <div class="card-mockup__header">
+            <span class="card-mockup__type">Legendary</span>
+            <span class="card-mockup__type">Édition Alpha</span>
+          </div>
+          <h2 class="card-mockup__name">Gardien de l'Aube</h2>
+          <div class="card-mockup__art">
+            <span>Ajoutez votre visuel</span>
+          </div>
+          <p class="card-mockup__desc">
+            Incarnez un protecteur ancestral et libérez des combos lumineux qui renversent le cours de la partie.
+          </p>
+          <div class="card-mockup__stats">
+            <span>ATK 320</span>
+            <span>DEF 280</span>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <section class="features" id="features">
+      <h2 class="features__title">Pourquoi vous allez adorer l'éditeur</h2>
+      <div class="feature-grid">
+        <article class="feature feature--accent">
+          <span class="feature__badge">Nouveau</span>
+          <h3>Import / Export JSON</h3>
+          <p>Enregistrez vos cartes, partagez-les en équipe et réimportez-les pour continuer vos itérations sans repartir de zéro.</p>
+        </article>
+        <article class="feature">
+          <h3>Archétypes prêts à jouer</h3>
+          <p>Choisissez un preset — Gardien céleste, Oracle des braises ou Druide sylvestre — puis adaptez-le à votre univers.</p>
+        </article>
+        <article class="feature">
+          <h3>Interface immersive</h3>
+          <p>Un formulaire à panneaux avec aperçu premium, capacité signature et jauges animées pour visualiser chaque détail.</p>
+        </article>
+        <article class="feature">
+          <h3>Sauvegarde intelligente</h3>
+          <p>Votre brouillon est conservé localement à chaque frappe. Revenez plus tard et retrouvez votre carte intacte.</p>
+        </article>
+      </div>
+    </section>
+
+    <footer>© <span id="year"></span> TCG Card Studio — Donnez vie à vos cartes.</footer>
+
+    <script>
+      const yearEl = document.getElementById('year');
+      if (yearEl) {
+        yearEl.textContent = new Date().getFullYear();
+      }
+    </script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
       }
 
       .hero__actions {
-        margin-top: 1.75rem;
+        margin-top: 2rem;
         display: flex;
         flex-wrap: wrap;
         gap: 0.75rem;
@@ -409,9 +409,8 @@
         <span class="hero__eyebrow">Créez votre univers</span>
         <h1>Donnez vie à vos cartes de jeu en quelques clics</h1>
         <p class="hero__description">
-          Composez vos cartes de jeu de façon intuitive&nbsp;: ajoutez une illustration, personnalisez le nom, la description et
-          ajustez les statistiques. Importez vos anciennes créations, sauvegardez automatiquement vos brouillons et exportez le
-          résultat en un clic.
+          Composez vos cartes de jeu de façon intuitive&nbsp;: personnalisez le nom, l'histoire et les statistiques, visualisez
+          le rendu final instantanément, importez vos anciennes créations et exportez vos decks en un clin d'œil.
         </p>
         <ul class="hero__highlights" role="list">
           <li><span>Nouveau</span> Importez ou exportez vos cartes au format JSON pour les partager instantanément.</li>
@@ -451,7 +450,7 @@
         <article class="feature feature--accent">
           <span class="feature__badge">Nouveau</span>
           <h3>Import / Export JSON</h3>
-          <p>Enregistrez vos cartes, partagez-les en équipe et réimportez-les pour continuer vos itérations sans repartir de zéro.</p>
+          <p>Enregistrez vos cartes, partagez-les en équipe et réimportez-les pour poursuivre vos itérations sans repartir de zéro.</p>
         </article>
         <article class="feature">
           <h3>Archétypes prêts à jouer</h3>
@@ -462,8 +461,8 @@
           <p>Un formulaire à panneaux avec aperçu premium, capacité signature et jauges animées pour visualiser chaque détail.</p>
         </article>
         <article class="feature">
-          <h3>Sauvegarde intelligente</h3>
-          <p>Votre brouillon est conservé localement à chaque frappe. Revenez plus tard et retrouvez votre carte intacte.</p>
+          <h3>Partage simplifié</h3>
+          <p>Exportez vos créations et retrouvez vos brouillons grâce à la sauvegarde automatique intégrée.</p>
         </article>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -410,11 +410,12 @@
         <h1>Donnez vie à vos cartes de jeu en quelques clics</h1>
         <p class="hero__description">
           Composez vos cartes de jeu de façon intuitive&nbsp;: personnalisez le nom, l'histoire et les statistiques, visualisez
-          le rendu final instantanément, importez vos anciennes créations et exportez vos decks en un clin d'œil.
+          le rendu final instantanément, importez vos anciennes créations en glisser-déposer et exportez ou copiez vos decks en
+          un clin d'œil.
         </p>
         <ul class="hero__highlights" role="list">
-          <li><span>Nouveau</span> Importez ou exportez vos cartes au format JSON pour les partager instantanément.</li>
-          <li><span>Archétypes</span> Lancez-vous grâce à des presets inspirants que vous adaptez en quelques secondes.</li>
+          <li><span>Glisser-déposer</span> Importez un fichier JSON directement dans l'éditeur ou cliquez pour le charger.</li>
+          <li><span>Partage</span> Copiez le JSON généré ou téléchargez-le au format fichier pour votre équipe.</li>
           <li><span>Brouillon</span> Votre progression est enregistrée localement à chaque modification.</li>
         </ul>
         <div class="hero__actions">
@@ -450,7 +451,7 @@
         <article class="feature feature--accent">
           <span class="feature__badge">Nouveau</span>
           <h3>Import / Export JSON</h3>
-          <p>Enregistrez vos cartes, partagez-les en équipe et réimportez-les pour poursuivre vos itérations sans repartir de zéro.</p>
+          <p>Glissez-déposez vos fichiers dans l'éditeur, importez-les depuis l'explorateur ou exportez-les en un clic pour reprendre vos itérations plus tard.</p>
         </article>
         <article class="feature">
           <h3>Archétypes prêts à jouer</h3>
@@ -462,7 +463,7 @@
         </article>
         <article class="feature">
           <h3>Partage simplifié</h3>
-          <p>Exportez vos créations et retrouvez vos brouillons grâce à la sauvegarde automatique intégrée.</p>
+          <p>Copiez le JSON généré, partagez-le à votre équipe ou téléchargez un fichier tout en profitant de la sauvegarde automatique.</p>
         </article>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- restructure the editor form with new identity, narration and stats sections, a preset gallery, and dedicated import/export controls alongside a richer preview card layout
- implement theme-aware live preview logic with stat meters, JSON import/export actions, preset loading and local draft auto-save support
- refresh the landing page hero and feature list to highlight import/export workflows, presets and autosave capabilities

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68c911496268832bb7862ddc053b04e8